### PR TITLE
Added missing catkin_depends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 catkin_package(
-  CATKIN_DEPENDS
+  CATKIN_DEPENDS sensor_msgs
   INCLUDE_DIRS include
   LIBRARIES kml_generator
 )


### PR DESCRIPTION
# Description
Added missing `sensor_msgs` catkin depends. When `kml_generator.hpp` is included in the package which doesn't find_package `sensor_msgs`, the error `kml_generator.hpp:10:10: fatal error: sensor_msgs/NavSatFix.h: No such file or directory` occurs.